### PR TITLE
Новый контроллер + рефакторинг + вопросы по именованию

### DIFF
--- a/src/pages/404/controller.js
+++ b/src/pages/404/controller.js
@@ -7,7 +7,6 @@ import body                 from 'drive-templates/build/body';
 import citySelector         from 'drive-templates/build/citySelector';
 import additionalNav        from 'drive-templates/build/additionalNav';
 import bottomScripts        from 'drive-templates/build/bottomScripts';
-import delimiter            from 'drive-templates/build/delimiter';
 import description          from 'drive-templates/build/description';
 import footer               from 'drive-templates/build/footer';
 import header               from 'drive-templates/build/header';
@@ -17,7 +16,6 @@ import mobileMenuTrigger    from 'drive-templates/build/mobileMenuTrigger';
 
 import mobileNav            from 'drive-templates/build/mobileNav';
 import nav                  from 'drive-templates/build/nav';
-import sprContainer         from 'drive-templates/build/sprContainer';
 import topControls          from 'drive-templates/build/topControls';
 import brandsList           from 'drive-templates/build/brandsList';
 
@@ -49,7 +47,6 @@ function controller(requestUrl) {
             }),
             page: 'Страница ' + requestUrl + ' не найдена',
             footer: footer(),
-            sprContainer: sprContainer(),
             bottomScripts: bottomScripts()
         })
     });

--- a/src/pages/bootstrap/getCarcassFn.js
+++ b/src/pages/bootstrap/getCarcassFn.js
@@ -13,9 +13,22 @@ import logo                 from 'drive-templates/build/logo';
 import mobileMenuTrigger    from 'drive-templates/build/mobileMenuTrigger';
 import mobileNav            from 'drive-templates/build/mobileNav';
 import nav                  from 'drive-templates/build/nav';
-import sprContainer         from 'drive-templates/build/sprContainer';
 import topControls          from 'drive-templates/build/topControls';
 import brandsList           from 'drive-templates/build/brandsList';
+
+import sprite               from 'drive-templates/build/partials/sprite';
+import backgroundSprite     from 'drive-templates/build/partials/backgroundSprite';
+import hr                   from 'drive-templates/build/partials/hr';
+import ins                  from 'drive-templates/build/partials/ins';
+
+import registerPartials from '../../utils/handlebars/registerPartials';
+
+registerPartials({
+    'sprite': sprite,
+    'backgroundSprite': backgroundSprite,
+    'ins': ins,
+    'hr': hr
+});
 
 const headerHtml = (cities) => {
     return header({
@@ -44,7 +57,6 @@ function getCarcass(brands, cities) {
                 }),
                 page: pageContentHtml,
                 footer: footer(),
-                sprContainer: sprContainer(),
                 bottomScripts: bottomScripts()
             })
         })

--- a/src/pages/brand/controller.js
+++ b/src/pages/brand/controller.js
@@ -1,0 +1,51 @@
+// testDrives page!
+
+import _ from 'underscore';
+import chalk from 'chalk';
+
+import moment from 'moment';
+moment.locale('ru');
+
+import pageContent          from 'drive-templates/build/pages/brand';
+import itemLarge            from 'drive-templates/build/itemLarge';
+import itemMedium           from 'drive-templates/build/itemMedium';
+import itemCompact          from 'drive-templates/build/itemCompact';
+import carIcon              from 'drive-templates/build/carIcon';
+import dealersList          from 'drive-templates/build/dealersList';
+import dealerItem           from 'drive-templates/build/dealerItem';
+import blogEntriesList      from 'drive-templates/build/blogEntriesList';
+import blogEntry            from 'drive-templates/build/blogEntry';
+
+// TODO: refactor to DRY
+const largeItemsHtml = (items) => {
+    return _.reduce(items, (result, item) => {
+        result = result + itemLarge(item);
+        return result;
+    }, '');
+}
+
+const mediumItemsHtml = (items) => {
+    return _.reduce(items, (result, item) => {
+        result = result + itemMedium(item);
+        return result;
+    }, '');
+}
+
+const composePageContentHtml = (brandFilterData, testDrivesData) => {
+    return pageContent({
+        testDrives: largeItemsHtml(testDrivesData.slice(0, 2)) + mediumItemsHtml(testDrivesData.slice(2, 14)),
+    })
+}
+
+function controller(brandFilterData, testDrivesData, getCarcassFn) {
+    let pageContentHtml = composePageContentHtml(
+        brandFilterData,
+        testDrivesData
+    );
+
+    return {
+        html: getCarcassFn(pageContentHtml)
+    }
+}
+
+export default controller;

--- a/src/pages/brand/controller.js
+++ b/src/pages/brand/controller.js
@@ -1,5 +1,3 @@
-// testDrives page!
-
 import _ from 'underscore';
 import chalk from 'chalk';
 
@@ -16,7 +14,6 @@ import dealerItem           from 'drive-templates/build/dealerItem';
 import blogEntriesList      from 'drive-templates/build/blogEntriesList';
 import blogEntry            from 'drive-templates/build/blogEntry';
 
-// TODO: refactor to DRY
 const largeItemsHtml = (items) => {
     return _.reduce(items, (result, item) => {
         result = result + itemLarge(item);

--- a/src/pages/brand/page.spec.js
+++ b/src/pages/brand/page.spec.js
@@ -1,0 +1,31 @@
+import wireDebugPlugin      from 'essential-wire/source/debug';
+import performancePlugin    from '../../plugins/performance';
+import requestPlugin        from '../../plugins/api/request';
+
+import { getEndpoint }   from '../../config/api';
+import controller from './controller';
+
+export default {
+    $plugins: [
+        wireDebugPlugin,
+        performancePlugin,
+        requestPlugin,
+    ],
+
+    testDrivesRequest: {
+        request: {
+            endpoint: getEndpoint('testDrives'),
+        }
+    },
+
+    body: {
+        create: {
+            module: controller,
+            args: [
+                {$ref: 'brandsRequest'},
+                {$ref: 'testDrivesRequest'},
+                {$ref: 'getCarcassFn'},
+            ]
+        }
+    }
+}

--- a/src/pages/common/abstract/disposition.js
+++ b/src/pages/common/abstract/disposition.js
@@ -44,7 +44,7 @@
 //         {{{footer}}}
 //     </div>
 // </div>
-// {{{sprContainer}}}
+// {{{backgroundSprite}}}
 // {{{bottomScripts}}}
 
 // ===================== utils ========================
@@ -80,7 +80,7 @@ body({
 
 footer()
 
-+ {{{ sprContainer }}}
++ {{{ backgroundSprite }}}
 + {{{ bottomScripts }}}
 
 // ===================== / pageWrapper (carcass) ========================

--- a/src/pages/common/page.js
+++ b/src/pages/common/page.js
@@ -17,12 +17,11 @@ import logo                 from 'drive-templates/build/logo';
 import mobileMenuTrigger    from 'drive-templates/build/mobileMenuTrigger';
 import mobileNav            from 'drive-templates/build/mobileNav';
 import nav                  from 'drive-templates/build/nav';
-import sprContainer         from 'drive-templates/build/sprContainer';
 import topControls          from 'drive-templates/build/topControls';
 import videoThumbnail       from 'drive-templates/build/videoThumbnail';
 import brandsList           from 'drive-templates/build/brandsList';
 
-const cacheReset = "v1"
+const cacheReset = "v1";
 
 const getHead = () => {
     return head({

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import newsPageSpec           from './pages/news/page.spec';
 import driveTestsPageSpec     from './pages/drive-tests/page.spec';
 import videoPageSpec          from './pages/video/page.spec';
 import demoPageSpec           from './pages/demo/page.spec';
+import brandPageSpec           from './pages/brand/page.spec';
 
 import noopPageSpec           from './pages/noop/page.spec';
 
@@ -26,7 +27,7 @@ let routesUnderConstruction = [
       'rewrite',
       'moderation',
       'feedback'
-]
+];
 
 const routes = [
       // TODO: handle aliases?
@@ -55,12 +56,15 @@ const routes = [
             url: '/404error',
             routeSpec: notFoundSpec
       },
-
       {
             url: '/demo',
             routeSpec: demoPageSpec
       },
-]
+      {
+            url: '/brand',
+            routeSpec: brandPageSpec
+      }
+];
 
 _.each(routesUnderConstruction, (item) => {
       routes.push({


### PR DESCRIPTION
Я добавил заготовку для страницы бренда — пока заглушку, не целиком, но по ходу дела возникли вопросы, решил поделиться в форме пулл-реквеста.

Работает все очень здорово, писать новые страницы — удобно и просто.

_Вопрос №1_
Как насчет перенести сюда весь код из репозитория [drive-templates](https://github.com/designeng/drive-templates)? Крайне неудобно писать шаблоны в одном месте, компилировать, пушить, а потом еще и перезапускать `npm i drive-templates` здесь. Логично держать весь фронтенд / миддленд в одном месте, к тому же отлаживать и тестировать Handlebars-шаблоны гораздо удобнее, подняв у себя локальный drive.ru. Что скажешь?

_Вопрос №2_
Я добавил регистрацию всех partials в контроллер каркаса (`bootstrap`), чтобы они были доступны из всех остальных контроллеров, правильно ли это? Получилось удобно, я смог убрать дублирование кода в нескольких местах.

_Вопрос №3_
Что лежит в `src/pages/common`? Это какой-то неиспользуемый код, судя по всему?

_Вопрос №4_
На мой взгляд, в коде много дублирования в части нейминга. То есть, скажем, при добавлении нового шаблона нужно написать его имя трижды:

``` javascript
import foo from 'drive-templates/build/foo';
...
return pagePart({
    ...
    foo: foo({content: 'bar'});
});
```

или (в случае partial):

``` javascript
import foo from 'drive-templates/build/partials/foo';
...
registerPartials({
    'foo': foo
});
```

Это кажется чрезмерным. Может быть, написать хелпер, который будет автоматически импортировать все шаблоны и сразу регистрировать все partials? Что-то типа `import * from 'drive-templates/build'`. А то, если меняется имя шаблона, то замучаешься рефакторить.

Еще есть предложение по кодстайлу — везде использовать одинарные кавычки (кроме JSON), можно выбрать какой-нибудь JSCS заодно — опыт показывает, что чем раньше его включишь, тем меньше потом придется чистить.
